### PR TITLE
Fix nginx /var/lib/nginx permission issue

### DIFF
--- a/alpine-consul-nginx/Dockerfile
+++ b/alpine-consul-nginx/Dockerfile
@@ -4,8 +4,7 @@ MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 # Install nginx
 RUN apk add --update nginx && \
     rm -rf /var/cache/apk/* && \
-    mkdir -p /tmp/nginx && \
-    chown -R nginx:www-data /tmp/nginx && \
+    chown -R nginx:www-data /var/lib/nginx && \    
     ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log
 

--- a/alpine-nginx/Dockerfile
+++ b/alpine-nginx/Dockerfile
@@ -4,8 +4,7 @@ MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 # Install nginx and have logs handle the s6-overlay way
 RUN apk add --update nginx && \
     rm -rf /var/cache/apk/* && \
-    mkdir -p /tmp/nginx && \
-    chown -R nginx:www-data /tmp/nginx
+    chown -R nginx:www-data /var/lib/nginx && \
 
 # Add the files
 ADD root /


### PR DESCRIPTION
This PR replaced the `/tmp/nginx` directory in `alpine-consul-nginx` and ` alpine-nginx` dockerfile with a `chown` on `/var/lib/nginx` instead to resolve permission issue like below:

```
open() "/var/lib/nginx/tmp/client_body/0000000001" failed (13: Permission denied)
```

@smebberson Please review!