### PR TITLE
Fix documentation containing broken instructions

### DIFF
--- a/alpine-consul-nginx/README.md
+++ b/alpine-consul-nginx/README.md
@@ -64,7 +64,7 @@ A basic nginx configuration is supplied with this image. But it's easy to overwr
 
 ### Restarting nginx
 
-If you're running another process to keep track of something down-stream (for example, automatically updating [nginx][nginx] proxy settings when a down-stream application server (nodejs, php, etc) restarts) execute the command `s6-svc -h /etc/services.d/nginx` to send a `SIGHUP` to nginx and have it reload its configuration, launch new worker process(es) using this new configuration, while gracefully shutting down the old worker processes.
+If you're running another process to keep track of something down-stream (for example, automatically updating [nginx][nginx] proxy settings when a down-stream application server (nodejs, php, etc) restarts) execute the command `s6-svc -h /var/run/s6/services/nginx` to send a `SIGHUP` to nginx and have it reload its configuration, launch new worker process(es) using this new configuration, while gracefully shutting down the old worker processes.
 
 ### nginx crash
 

--- a/alpine-nginx/README.md
+++ b/alpine-nginx/README.md
@@ -78,7 +78,7 @@ A basic nginx configuration is supplied with this image. But it's easy to overwr
 
 ### Restarting nginx
 
-If you're running another process to keep track of something down-stream (for example, automatically updating [nginx][nginx] proxy settings when a down-stream application server (nodejs, php, etc) restarts) execute the command `s6-svc -h /var /run/s6/services/nginx` to send a `SIGHUP` to nginx and have it reload its configuration, launch new worker process(es) using this new configuration, while gracefully shutting down the old worker processes.
+If you're running another process to keep track of something down-stream (for example, automatically updating [nginx][nginx] proxy settings when a down-stream application server (nodejs, php, etc) restarts) execute the command `s6-svc -h /var/run/s6/services/nginx` to send a `SIGHUP` to nginx and have it reload its configuration, launch new worker process(es) using this new configuration, while gracefully shutting down the old worker processes.
 
 ### nginx crash
 


### PR DESCRIPTION
The `/var /run/...` caused nasty issues due to my copy & paste last week so here's a fix for that! :)

Signed-off-by: Matthew Valimaki <matthew.valimaki@gmail.com>