### PR TITLE
Depend on Alpine 3.3 and use apk's new --no-cache flag

### DIFF
--- a/alpine-apache/Dockerfile
+++ b/alpine-apache/Dockerfile
@@ -2,8 +2,7 @@ FROM smebberson/alpine-base:1.2.0
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Install apache
-RUN apk add --update apache2=2.4.16-r0 apache2-utils=2.4.16-r0 && \
-    rm -rf /var/cache/apk/*
+RUN apk --no-cache add apache2=2.4.16-r0 apache2-utils=2.4.16-r0
 
 # Add the files
 ADD root /

--- a/alpine-base/Dockerfile
+++ b/alpine-base/Dockerfile
@@ -1,20 +1,18 @@
-FROM alpine:3.2
+FROM alpine:3.3
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Add commonly used packages
-RUN apk add --update bind-tools && \
-    rm -rf /var/cache/apk/*
+RUN apk --no-cache add bind-tools
 
 # Add s6-overlay
 ENV S6_OVERLAY_VERSION=v1.16.0.1 GODNSMASQ_VERSION=0.9.8
 
-RUN apk add --update curl && \
+RUN apk --no-cache add curl && \
     curl -sSL https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz \
     | tar xvfz - -C / && \
     curl -sSL https://github.com/janeczku/go-dnsmasq/releases/download/${GODNSMASQ_VERSION}/go-dnsmasq-min_linux-amd64 -o /bin/go-dnsmasq && \
     chmod +x /bin/go-dnsmasq && \
-    apk del curl && \
-    rm -rf /var/cache/apk/*
+    apk del curl
 
 ADD root /
 

--- a/alpine-confd/Dockerfile
+++ b/alpine-confd/Dockerfile
@@ -5,11 +5,11 @@ ENV CONFD_VERSION=0.11.0
 
 # Statically build confd for Alpine Linux :)
 RUN echo "http://dl-2.alpinelinux.org/alpine/latest-stable/community" >> /etc/apk/repositories && \
-    apk add --update go git gcc musl-dev && \
+    apk --no-cache add go git gcc musl-dev && \
     git clone https://github.com/kelseyhightower/confd.git /src/confd && \
     cd /src/confd/src/github.com/kelseyhightower/confd/ && \
     GOPATH=/src/confd/vendor:/src/confd go build -a -installsuffix cgo -ldflags '-extld ld -extldflags -static' -x . && \
     mv ./confd /bin/ && \
     chmod +x /bin/confd && \
     apk del go git gcc musl-dev && \
-    rm -rf /var/cache/apk/* /src
+    rm -rf /src

--- a/alpine-consul-apache/Dockerfile
+++ b/alpine-consul-apache/Dockerfile
@@ -2,8 +2,7 @@ FROM smebberson/alpine-consul-base:1.1.0
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Install apache
-RUN apk add --update apache2=2.4.16-r0 apache2-utils=2.4.16-r0 && \
-    rm -rf /var/cache/apk/* && \
+RUN apk --no-cache add apache2=2.4.16-r0 apache2-utils=2.4.16-r0 && \
     sed -i 's/CustomLog logs\/access.log combined/CustomLog logs\/access.log combined env=!dontlog/g' /etc/apache2/httpd.conf
 
 # Add the files

--- a/alpine-consul-nginx-nodejs/Dockerfile
+++ b/alpine-consul-nginx-nodejs/Dockerfile
@@ -2,6 +2,5 @@ FROM smebberson/alpine-consul-nginx
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Install Node.js, and the latest version of npm (and Python in case any npm modules require building)
-RUN apk add --update nodejs git python make && \
-    rm -rf /var/cache/apk/* && \
+RUN apk --no-cache add nodejs git python make && \
     npm install -g npm

--- a/alpine-consul-nginx/Dockerfile
+++ b/alpine-consul-nginx/Dockerfile
@@ -2,8 +2,7 @@ FROM smebberson/alpine-consul-base:1.0.0
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Install nginx
-RUN apk add --update nginx && \
-    rm -rf /var/cache/apk/* && \
+RUN apk --no-cache add nginx && \
     chown -R nginx:www-data /var/lib/nginx && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log

--- a/alpine-consul-nodejs/Dockerfile
+++ b/alpine-consul-nodejs/Dockerfile
@@ -2,6 +2,5 @@ FROM smebberson/alpine-consul-base
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Install Node.js, and the latest version of npm (and Python in case any npm modules require building)
-RUN apk add --update nodejs git python make && \
-    rm -rf /var/cache/apk/* && \
+RUN apk --no-cache add nodejs git python make && \
     npm install -g npm

--- a/alpine-consul-redis/Dockerfile
+++ b/alpine-consul-redis/Dockerfile
@@ -2,8 +2,7 @@ FROM smebberson/alpine-consul-base
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Install redis
-RUN apk add --update redis && \
-    rm -rf /var/cache/apk/* && \
+RUN apk --no-cache add redis && \
     mkdir -p /data/redis && \
     chown -R redis:redis /data/redis && \
     echo -e "include /etc/redis-local.conf\n" >> /etc/redis.conf

--- a/alpine-consul/Dockerfile
+++ b/alpine-consul/Dockerfile
@@ -6,7 +6,7 @@ ENV CONSUL_VERSION=0.5.2 GOMAXPROCS=2
 # Download and install Consul
 # We are building it ourselves, because Alpine Linux doesn't use glibc
 RUN export GOPATH=/go && \
-    apk add --update go git gcc musl-dev make bash && \
+    apk --no-cache add go git gcc musl-dev make bash && \
     go get github.com/hashicorp/consul && \
     cd $GOPATH/src/github.com/hashicorp/consul && \
     git checkout -q --detach "v$CONSUL_VERSION" && \
@@ -14,7 +14,6 @@ RUN export GOPATH=/go && \
     mv bin/consul /bin && \
     rm -rf $GOPATH && \
     apk del go git gcc musl-dev make bash && \
-    rm -rf /var/cache/apk/* && \
     addgroup consul && \
     adduser -D -G consul consul && \
     mkdir -p /data/consul && \

--- a/alpine-nginx-nodejs/Dockerfile
+++ b/alpine-nginx-nodejs/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 ENV NODE_VERSION=v4.2.2 NPM_VERSION=3
 
-RUN apk add --update git curl make gcc g++ python linux-headers libgcc libstdc++ && \
+RUN apk --no-cache add git curl make gcc g++ python linux-headers libgcc libstdc++ && \
     curl -sSL https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}.tar.gz | tar -xz && \
     cd /node-${NODE_VERSION} && \
     ./configure --prefix=/usr && \
@@ -13,5 +13,5 @@ RUN apk add --update git curl make gcc g++ python linux-headers libgcc libstdc++
     npm install -g npm@${NPM_VERSION} && \
     apk del curl gcc g++ linux-headers && \
     rm -rf /etc/ssl /node-${NODE_VERSION} \
-    /usr/share/man /tmp/* /var/cache/apk/* /root/.npm /root/.node-gyp \
+    /usr/share/man /tmp/* /root/.npm /root/.node-gyp \
     /usr/lib/node_modules/npm/man /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/html

--- a/alpine-nginx/Dockerfile
+++ b/alpine-nginx/Dockerfile
@@ -2,8 +2,7 @@ FROM smebberson/alpine-base:1.2.0
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Install nginx
-RUN apk add --update nginx=1.8.0-r1 && \
-    rm -rf /var/cache/apk/* && \
+RUN apk --no-cache add nginx=1.8.0-r1 && \
     chown -R nginx:www-data /var/lib/nginx
 
 # Add the files

--- a/alpine-nodejs/Dockerfile
+++ b/alpine-nodejs/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 ENV NODE_VERSION=v5.2.0 NPM_VERSION=3
 
-RUN apk add --update git curl make gcc g++ python linux-headers libgcc libstdc++ binutils-gold && \
+RUN apk --no-cache add git curl make gcc g++ python linux-headers libgcc libstdc++ binutils-gold && \
     curl -sSL https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}.tar.gz | tar -xz && \
     cd /node-${NODE_VERSION} && \
     ./configure --prefix=/usr --without-snapshot --fully-static && \
@@ -13,5 +13,5 @@ RUN apk add --update git curl make gcc g++ python linux-headers libgcc libstdc++
     npm install -g npm@${NPM_VERSION} && \
     apk del gcc g++ linux-headers libgcc libstdc++ binutils-gold && \
     rm -rf /etc/ssl /node-${NODE_VERSION} /usr/include \
-    /usr/share/man /tmp/* /var/cache/apk/* /root/.npm /root/.node-gyp \
+    /usr/share/man /tmp/* /root/.npm /root/.node-gyp \
     /usr/lib/node_modules/npm/man /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/html

--- a/alpine-rabbitmq/Dockerfile
+++ b/alpine-rabbitmq/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 ENV RABBITMQ_VERSION=3.5.7 ERLANG_PKG_VERSION=18.1-r5
 
 # Setup Erlang, download RabbitMQ and setup the management plugin
-RUN apk add --update curl tar gzip bash && \
+RUN apk --no-cache add curl tar gzip bash && \
     echo "http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk add --update-cache --allow-untrusted \
+    apk --no-cache add --allow-untrusted \
         erlang=${ERLANG_PKG_VERSION} erlang-mnesia=${ERLANG_PKG_VERSION} \
         erlang-public-key=${ERLANG_PKG_VERSION} erlang-crypto=${ERLANG_PKG_VERSION} \
         erlang-ssl=${ERLANG_PKG_VERSION} erlang-sasl=${ERLANG_PKG_VERSION} \
@@ -16,7 +16,6 @@ RUN apk add --update curl tar gzip bash && \
     curl -sSL https://www.rabbitmq.com/releases/rabbitmq-server/v${RABBITMQ_VERSION}/rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.gz | tar -xz -C / --strip-components 1 && \
     rm -rf /share/**/rabbitmq*.gz && \
     apk del --purge tar gzip curl && \
-    rm -rf /var/cache/apk/* && \
     addgroup rabbitmq && \
     adduser -DS -G rabbitmq -s /bin/sh -h /var/lib/rabbitmq rabbitmq && \
     mkdir -p /data/rabbitmq

--- a/alpine-redis/Dockerfile
+++ b/alpine-redis/Dockerfile
@@ -2,8 +2,7 @@ FROM smebberson/alpine-base
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Install redis
-RUN apk add --update redis && \
-    rm -rf /var/cache/apk/* && \
+RUN apk --no-cache add redis && \
     mkdir /data && \
     chown -R redis:redis /data && \
     echo -e "include /etc/redis-local.conf\n" >> /etc/redis.conf


### PR DESCRIPTION
See:
https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache

This commit alone won't make all the images work, since it doesn't update the version references in the sub-images to e.g. `smebberson/alpine-base:1.2.0`