### PR TITLE
Ensure /run/apache2/ directory is created

### DIFF
--- a/alpine-apache/Dockerfile
+++ b/alpine-apache/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 # Install apache
 RUN apk add --no-cache apache2=2.4.17-r4 apache2-utils=2.4.17-r4
 
+RUN mkdir -p /run/apache2/
+
 # Add the files
 ADD root /
 


### PR DESCRIPTION
My container was stopping even when using the base image on its own (not my image which is based on alpine-apache):

```
$ docker run --rm smebberson/alpine-apache:2.0.0
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] 30-resolver: executing... 
[cont-init.d] 30-resolver: exited 0.
[cont-init.d] 40-resolver: executing... 
[cont-init.d] 40-resolver: exited 0.
[cont-init.d] done.
[services.d] starting services
[services.d] done.
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.4. Set the 'ServerName' directive globally to suppress this message
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
[s6-finish] syncing disks.
[s6-finish] sending all processes the TERM signal.
[s6-finish] sending all processes the KILL signal and exiting.
```

Writing my own dockerfile which extended the alpine-apache:2.0.0 image and symlinked the logs to stdout (as described in the README) gave me more info (I'm using docker-compose):
```
$ docker-compose up
Recreating web_1
Attaching to web_1
web_1  | [s6-init] making user provided files available at /var/run/s6/etc...exited 0.
web_1  | [s6-init] ensuring user provided files have correct perms...exited 0.
web_1  | [fix-attrs.d] applying ownership & permissions fixes...
web_1  | [fix-attrs.d] done.
web_1  | [cont-init.d] executing container initialization scripts...
web_1  | [cont-init.d] 30-resolver: executing... 
web_1  | [cont-init.d] 30-resolver: exited 0.
web_1  | [cont-init.d] 40-resolver: executing... 
web_1  | [cont-init.d] 40-resolver: exited 0.
web_1  | [cont-init.d] done.
web_1  | [services.d] starting services
web_1  | [services.d] done.
web_1  | AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.28.0.2. Set the 'ServerName' directive globally to suppress this message
web_1  | AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.28.0.2. Set the 'ServerName' directive globally to suppress this message
web_1  | [Thu Oct 13 11:58:26.675852 2016] [core:error] [pid 197] (2)No such file or directory: AH00099: could not create /run/apache2/httpd.pid
web_1  | [Thu Oct 13 11:58:26.676343 2016] [core:error] [pid 197] AH00100: httpd: could not log pid to file /run/apache2/httpd.pid
web_1  | [cont-finish.d] executing container finish scripts...
web_1  | [cont-finish.d] done.
web_1  | [s6-finish] syncing disks.
web_1  | [s6-finish] sending all processes the TERM signal.
web_1  | [s6-finish] sending all processes the KILL signal and exiting.
web_1 exited with code 0
```

Adding `RUN mkdir -p /run/apache2/` to my Dockerfile fixed this.

