### PR TITLE
Base images should rarely expose ports

### DIFF
--- a/alpine-nginx/Dockerfile
+++ b/alpine-nginx/Dockerfile
@@ -10,5 +10,6 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/v3.3/main" >> /etc/apk/repositories
 # Add the files
 ADD root /
 
-# Expose the ports for nginx
-EXPOSE 80 443
+# link the logs to stdout/stderr so they get surfaced to docker
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log


### PR DESCRIPTION
Given that it is unlikely that the alpine-nginx image would be deployed
as-is, it should not expose ports. Instead that should be left to the
image that uses alpine-nginx as its base.

This is especially true because, unlike `CMD` or `ENTRYPOINT` a derived
image _cannot_ override the `EXPOSE` command of a base image. This means
that should a derived image want nginx to _not_ expose ports 80 or 443,
they cannot use this as a base image.

Also, nginx logs should always be redirected to stdout and stderr, and
therefore the commands to make this happen should remain the
responsibility of alpine-nginx base image.
