### PR TITLE
Version bump: nginx + nodejs

### DIFF
--- a/alpine-nginx-nodejs/Dockerfile
+++ b/alpine-nginx-nodejs/Dockerfile
@@ -1,9 +1,9 @@
-FROM smebberson/alpine-nginx:3.0.0
+FROM smebberson/alpine-nginx:3.9
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
-ENV NODE_VERSION=v6.4.0 NPM_VERSION=3
+ENV NODE_VERSION=v12.13.1 NPM_VERSION=6.13.1
 
-RUN echo "http://dl-4.alpinelinux.org/alpine/v3.2/main" >> /etc/apk/repositories && \
+RUN echo "http://dl-4.alpinelinux.org/alpine/v3.9/main" >> /etc/apk/repositories && \
     apk add --update git curl make gcc g++ python linux-headers libgcc libstdc++ binutils-gold && \
     curl -sSL https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}.tar.gz | tar -xz && \
     cd /node-${NODE_VERSION} && \

--- a/alpine-nginx/Dockerfile
+++ b/alpine-nginx/Dockerfile
@@ -1,9 +1,9 @@
-FROM smebberson/alpine-base:3.0.0
+FROM smebberson/alpine-base:3.9
 MAINTAINER Scott Mebberson <scott@scottmebberson.com>
 
 # Install nginx
-RUN echo "http://dl-4.alpinelinux.org/alpine/v3.3/main" >> /etc/apk/repositories && \
-    apk add --update nginx=1.8.1-r1 && \
+RUN echo "http://dl-4.alpinelinux.org/alpine/v3.9/main" >> /etc/apk/repositories && \
+    apk add --update nginx=1.14.2-r4 && \
     rm -rf /var/cache/apk/* && \
     chown -R nginx:www-data /var/lib/nginx
 


### PR DESCRIPTION
Hi,
We used your image for quite some years on our project, but now we're running into issues with new node packages requiring and updated `npm`, so we made a fork and updated those, along with `nginx` one to `3.9` alpine target from yourself. Might be useful to merge this and repush new tags for the next guy ™

Thanks.